### PR TITLE
Add app: Kubo (IPFS)

### DIFF
--- a/apps/kubo/compose.yml
+++ b/apps/kubo/compose.yml
@@ -2,12 +2,6 @@ services:
   kubo:
     container_name: kubo
     image: ipfs/kubo:latest
-    command: > # Command needed to make the WebUI usable without access to the command line
-      sh -c "
-        ipfs config --json API.HTTPHeaders.Access-Control-Allow-Origin '[\"*\"]' &&
-        ipfs config --json API.HTTPHeaders.Access-Control-Allow-Methods '[\"PUT\", \"POST\"]' &&
-        exec /usr/local/bin/start_ipfs daemon --migrate=true
-      "
     environment:
       - IPFS_PROFILE=lowpower
     volumes:


### PR DESCRIPTION
Added the app "Kubo" for self-hosting an IPFS node.

Wondering if port 4001 (TCP+UDP) needs to be mapped through to the host so that IPFS's P2P connection can work properly.