### PR TITLE
Add Craftbox, Update Dropgate Server meta

### DIFF
--- a/apps/craftbox/compose.yml
+++ b/apps/craftbox/compose.yml
@@ -1,0 +1,22 @@
+services:
+  craftbox:
+    image: willtda/craftbox:latest
+    pull_policy: always
+    container_name: craftbox
+    labels:
+      yantr.app: "craftbox"
+      yantr.service: "Game Server"
+    ports:
+      - "6464:6464"
+      - "25500-25600:25500-25600/tcp"
+      - "25500-25600:25500-25600/udp"
+    environment:
+      SERVER_PORT: ${PORT:-6464}
+      NODE_ENV: ${NODE_ENV:-development}
+      TRUST_PROXY: ${TRUST_PROXY:-false}
+    volumes:
+      - craftbox:/app/data
+    restart: unless-stopped
+
+volumes:
+  craftbox:

--- a/apps/craftbox/compose.yml
+++ b/apps/craftbox/compose.yml
@@ -7,7 +7,7 @@ services:
       yantr.app: "craftbox"
       yantr.service: "Game Server"
     ports:
-      - "6464:6464"
+      - "6464"
       - "25500-25600:25500-25600/tcp"
       - "25500-25600:25500-25600/udp"
     environment:

--- a/apps/craftbox/info.json
+++ b/apps/craftbox/info.json
@@ -1,0 +1,40 @@
+{
+  "name": "Craftbox",
+  "logo": "bafkreigoofakv37dcp75c6zrdtmx5o5wduwv6qthbrbupzhjci2ljqwfwy",
+  "tags": [
+    "gaming",
+    "server",
+    "minecraft",
+    "panel",
+    "admin",
+    "tools"
+  ],
+  "short_description": "A modern self-hosted platform for managing Minecraft servers with built-in mod support.",
+  "description": "Craftbox is a self-hosted web panel for creating, configuring, monitoring, and managing Minecraft servers — no command-line expertise or dodgy download pages required.",
+  "usecases": [
+    "Run and manage multiple Minecraft servers from a single panel, each with its own console, watchdog, and configuration.",
+    "Choose from Vanilla, Paper, Purpur, Folia, Fabric, Forge, NeoForge, and custom JAR uploads.",
+    "One-click manual backups, scheduled backups with retention policies, and one-click restore.",
+    "Upload and manage JAR files for plugins (Paper/Purpur/Folia) and mods (Fabric/Forge/NeoForge).",
+    "Keep yourself and players informed with public status pages, live player tracking, resource monitoring, and event history."
+  ],
+  "website": "https://diamonddigital.dev/projects/craftbox",
+  "dependencies": [],
+  "ports": [
+    {
+      "port": 6464,
+      "protocol": "HTTP",
+      "label": "Web UI"
+    },
+    {
+      "port": "25500-25600",
+      "protocol": "TCP",
+      "label": "Minecraft Java Server"
+    },
+    {
+      "port": "25500-25600",
+      "protocol": "UDP",
+      "label": "Plugins/Mods"
+    }
+  ]
+}

--- a/apps/dropgate-server/compose.yml
+++ b/apps/dropgate-server/compose.yml
@@ -1,6 +1,7 @@
 services:
   dropgate-server:
     image: willtda/dropgate-server:latest
+    pull_policy: always
     container_name: dropgate-server
     labels:
       yantr.app: "dropgate-server"


### PR DESCRIPTION
As the PR title describes, this submission:
- Adds Craftbox (https://diamonddigital.dev/projects/craftbox).
- Updates Dropgate Server metadata (`docker-compose` to add `pull_policy: always`).

These changes have been tested on my machine using Docker Desktop for Windows.