### PR TITLE
Streamline the license: public source, no commercial use

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,19 @@
+Yantr is source-available.
+
+You may use, study, change, and share it for personal, hobby, and
+homelab purposes. Schools, charities, and other noncommercial
+organizations may use it too.
+
+You may not use it for commercial purposes. That includes selling
+Yantr, hosting it as a paid product, or using it to run a business.
+
+The binding terms are the PolyForm Noncommercial License 1.0.0 below.
+https://polyformproject.org/licenses/noncommercial/1.0.0
+
+Required Notice: Copyright besoeasy (https://github.com/besoeasy/yantr)
+
+---
+
 PolyForm Noncommercial License 1.0.0
 https://polyformproject.org/licenses/noncommercial/1.0.0
 Acceptance

--- a/README.md
+++ b/README.md
@@ -122,6 +122,19 @@ PRs welcome.
 
 ---
 
+## License
+
+Yantr is source-available under the [PolyForm Noncommercial License 1.0.0](LICENSE).
+
+- Personal, hobby, and homelab use: yes
+- Study, change, and share the source under the same terms: yes
+- Schools, charities, and other noncommercial orgs: yes
+- Commercial use (sell it, host it as a paid product, run a business on it): no
+
+The source stays public. The short version is at the top of [`LICENSE`](LICENSE).
+
+---
+
 <div align="center">
   <sub>Vue 3 · Go · Docker · Tailwind CSS</sub><br/><br/>
   <a href="https://yantr.org">yantr.org</a> · <a href="https://github.com/besoeasy/yantr/issues">Issues</a> · <a href="AGENTS.md">App Format Guide</a>

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "yantr",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "type": "module",
   "scripts": {
     "dev": "vite --host",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -648,9 +648,9 @@
     "loginNote": "Ihr Schlüssel ist in diesem Browser gespeichert."
   },
   "openSourceCard": {
-    "label": "Open Source",
-    "title": "Yantr is Open Source.",
-    "description": "Fully open source and community-driven. Star the repository, contribute code, or help us improve by reporting issues.",
+    "label": "Quelloffen",
+    "title": "Öffentlich entwickelt.",
+    "description": "Der Quellcode ist öffentlich. Kostenlos für privat und Homelab — nicht für kommerzielle Nutzung. Repository markieren, beitragen oder Probleme melden.",
     "cta": "Star on GitHub"
   },
   "cloudflaredCard": {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -648,9 +648,9 @@
     "loginNote": "Your key is stored in this browser. Use this device to access Yantr."
   },
   "openSourceCard": {
-    "label": "Open Source",
-    "title": "Yantr is Open Source.",
-    "description": "Fully open source and community-driven. Star the repository, contribute code, or help us improve by reporting issues.",
+    "label": "Source available",
+    "title": "Built in the open.",
+    "description": "The source is public. Free for personal and homelab use — not for commercial use. Star the repo, contribute, or report issues.",
     "cta": "Star on GitHub"
   },
   "cloudflaredCard": {

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -648,9 +648,9 @@
     "loginNote": "Su clave está almacenada en este navegador."
   },
   "openSourceCard": {
-    "label": "Open Source",
-    "title": "Yantr is Open Source.",
-    "description": "Fully open source and community-driven. Star the repository, contribute code, or help us improve by reporting issues.",
+    "label": "Código público",
+    "title": "Hecho a la vista.",
+    "description": "El código es público. Gratis para uso personal y homelab — no para uso comercial. Da estrella, contribuye o reporta problemas.",
     "cta": "Star on GitHub"
   },
   "cloudflaredCard": {

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -648,9 +648,9 @@
     "loginNote": "Votre clé est stockée dans ce navigateur."
   },
   "openSourceCard": {
-    "label": "Open Source",
-    "title": "Yantr is Open Source.",
-    "description": "Fully open source and community-driven. Star the repository, contribute code, or help us improve by reporting issues.",
+    "label": "Code public",
+    "title": "Fait au grand jour.",
+    "description": "Le code est public. Gratuit pour un usage personnel et homelab — pas d'usage commercial. Mettez une étoile, contribuez ou signalez un problème.",
     "cta": "Star on GitHub"
   },
   "cloudflaredCard": {

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -648,9 +648,9 @@
     "loginNote": "キーはこのブラウザに保存されています。"
   },
   "openSourceCard": {
-    "label": "Open Source",
-    "title": "Yantr is Open Source.",
-    "description": "Fully open source and community-driven. Star the repository, contribute code, or help us improve by reporting issues.",
+    "label": "ソース公開",
+    "title": "公開して作っています。",
+    "description": "ソースは公開。個人・ホームラボは無料。商用利用は不可。スター、貢献、Issue 歓迎。",
     "cta": "Star on GitHub"
   },
   "cloudflaredCard": {

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -648,9 +648,9 @@
     "loginNote": "Ваш ключ сохранен в этом браузере."
   },
   "openSourceCard": {
-    "label": "Open Source",
-    "title": "Yantr is Open Source.",
-    "description": "Fully open source and community-driven. Star the repository, contribute code, or help us improve by reporting issues.",
+    "label": "Исходники открыты",
+    "title": "Делаем открыто.",
+    "description": "Исходный код публичен. Бесплатно для личного и хомлаб использования — не для коммерции. Поставьте звезду, внесите вклад или сообщите о проблеме.",
     "cta": "Star on GitHub"
   },
   "cloudflaredCard": {

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -648,9 +648,9 @@
     "loginNote": "您的密钥已存储在此浏览器中。"
   },
   "openSourceCard": {
-    "label": "Open Source",
-    "title": "Yantr is Open Source.",
-    "description": "Fully open source and community-driven. Star the repository, contribute code, or help us improve by reporting issues.",
+    "label": "源码公开",
+    "title": "在公开中构建。",
+    "description": "源码公开。个人和家庭实验室可免费使用，不可商用。欢迎标星、贡献或反馈问题。",
     "cta": "Star on GitHub"
   },
   "cloudflaredCard": {

--- a/website/index.html
+++ b/website/index.html
@@ -10,7 +10,7 @@
     />
     <meta
       name="keywords"
-      content="homelab, self-hosted, self-hosting, docker, docker compose, app store, homelab app store, selfhosted apps, jellyfin, nextcloud, ollama, umbrel alternative, casaos alternative, plex alternative, free open source, yantr"
+      content="homelab, self-hosted, self-hosting, docker, docker compose, app store, homelab app store, selfhosted apps, jellyfin, nextcloud, ollama, umbrel alternative, casaos alternative, plex alternative, source available, yantr"
     />
     <meta name="author" content="Yantr" />
     <meta name="theme-color" content="#ffffff" />
@@ -70,7 +70,7 @@
       "url": "https://yantr.org/",
       "downloadUrl": "https://github.com/besoeasy/yantr",
       "image": "https://yantr.org/banner.png",
-      "description": "Open-source homelab app store. Deploy popular self-hosted apps on your own hardware with a single Docker Compose command.",
+      "description": "Source-available homelab app store. Deploy popular self-hosted apps on your own hardware with a single Docker Compose command. Free for personal and homelab use.",
       "offers": {
         "@type": "Offer",
         "price": "0",
@@ -918,7 +918,7 @@
           <!-- Header -->
           <div class="text-center mb-14">
             <p class="text-[11px] uppercase tracking-[0.25em] text-emerald-400/80 font-semibold mb-4">Community</p>
-            <h2 class="text-4xl sm:text-5xl font-bold font-sans tracking-tight mb-5 text-white leading-tight">Built by the<br class="hidden sm:block"/> open source community</h2>
+            <h2 class="text-4xl sm:text-5xl font-bold font-sans tracking-tight mb-5 text-white leading-tight">Built in the open<br class="hidden sm:block"/> by the community</h2>
             <p class="text-white/45 font-sans text-base max-w-md mx-auto leading-relaxed">Every app, fix, and improvement comes from contributors like you.</p>
             <p class="text-xs text-white/25 font-mono mt-3" id="contributors-count"></p>
           </div>
@@ -1104,9 +1104,9 @@
             </div>
 
             <div class="border border-white/10 rounded-2xl p-6 sm:p-8 hover:border-white/25 hover:bg-white/[0.04] transition-all duration-300">
-              <h3 class="text-base font-bold font-sans mb-3 text-white">Is Yantr free and open source?</h3>
+              <h3 class="text-base font-bold font-sans mb-3 text-white">Is Yantr free? Can I see the source?</h3>
               <p class="text-white/50 leading-relaxed text-sm">
-                Yes. Yantr is open source under the MIT license, so you can use, inspect, and self-host it without subscription lock-in.
+                Yes. The source is public on GitHub. Personal and homelab use is free. Commercial use is not allowed — see the PolyForm Noncommercial License.
               </p>
             </div>
           </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The repo was already PolyForm Noncommercial. The site still said MIT, and the UI said “fully open source.” That is the opposite of a clear rule.

**What you asked for:** source stays public; commercial use is not allowed.

OSI “open source” requires commercial use. A custom license would be worse. PolyForm Noncommercial 1.0.0 is the standard terms for this intent, so those stay the binding text.

**This PR**

- Adds a plain-English summary at the top of `LICENSE` (homelab yes, commercial no)
- Sets `"license": "PolyForm-Noncommercial-1.0.0"` in `package.json`
- Documents the same rule in the README
- Fixes the website FAQ that claimed MIT
- Updates the in-app card so it no longer says “fully open source”

I am not a lawyer. This does not change who can use Yantr — it makes the existing rule readable and consistent.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c071ec2e-88ab-4d91-ba69-4ebeeb07634b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c071ec2e-88ab-4d91-ba69-4ebeeb07634b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

