### PR TITLE
Add yantr-bot custom app

### DIFF
--- a/apps/yantr-bot/Dockerfile
+++ b/apps/yantr-bot/Dockerfile
@@ -1,0 +1,19 @@
+FROM node:lts-bookworm-slim
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        git \
+        curl \
+        ca-certificates \
+        python3 \
+        bash && \
+    rm -rf /var/lib/apt/lists/* && \
+    npm install -g @grinev/opencode-telegram-bot opencode-ai && \
+    npm cache clean --force
+
+WORKDIR /app
+ENV HOME=/app
+
+VOLUME ["/app"]
+
+CMD ["opencode-telegram", "start"]

--- a/apps/yantr-bot/compose.yml
+++ b/apps/yantr-bot/compose.yml
@@ -1,0 +1,36 @@
+x-yantr:
+  name: yantrbot
+  tags: [ai, telegram, coding, bot, docker]
+  short_description: "Telegram client for OpenCode so you can run AI coding tasks from your phone."
+  description: >
+    Yantr Bot is a self-hosted Telegram client for OpenCode. Send prompts from
+    your phone to run AI coding tasks, manage sessions, switch models, and
+    schedule work while everything stays on your server. Access is limited to
+    your Telegram user ID. OpenCode auto-restarts when health checks fail.
+  usecases: ["Run OpenCode AI coding tasks from Telegram on your phone.", "Manage sessions, models, and scheduled OpenCode work without opening a desktop TUI."]
+  website: "https://github.com/grinev/opencode-telegram-bot"
+  customapp: true
+  notes: ["Create a bot with @BotFather and set TELEGRAM_BOT_TOKEN.", "Get your numeric Telegram user ID from @userinfobot and set TELEGRAM_ALLOWED_USER_ID — only that user can talk to the bot.", "OpenCode runs inside this container at http://localhost:4096 and auto-restarts if health checks fail."]
+
+services:
+  yantr-bot:
+    build: .
+    working_dir: /app
+    labels:
+      yantr.app: "yantr-bot"
+    environment:
+      HOME: /app
+      TELEGRAM_BOT_TOKEN: ${TELEGRAM_BOT_TOKEN}
+      TELEGRAM_ALLOWED_USER_ID: ${TELEGRAM_ALLOWED_USER_ID:-}
+      OPENCODE_MODEL_PROVIDER: ${OPENCODE_MODEL_PROVIDER:-opencode}
+      OPENCODE_MODEL_ID: ${OPENCODE_MODEL_ID:-big-pickle}
+      OPENCODE_API_URL: ${OPENCODE_API_URL:-http://localhost:4096}
+      OPENCODE_AUTO_RESTART_ENABLED: ${OPENCODE_AUTO_RESTART_ENABLED:-true}
+    volumes:
+      - yantr_bot_data:/app
+    tty: true
+    stdin_open: true
+    restart: unless-stopped
+
+volumes:
+  yantr_bot_data:

--- a/apps/yantr-bot/logo.svg
+++ b/apps/yantr-bot/logo.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewBox="0 0 256 256" fill="none">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="256" y2="256" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#0B1220"/>
+      <stop offset="100%" stop-color="#1E293B"/>
+    </linearGradient>
+    <linearGradient id="plane" x1="48" y1="48" x2="208" y2="208" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#38BDF8"/>
+      <stop offset="100%" stop-color="#2563EB"/>
+    </linearGradient>
+    <linearGradient id="glow" x1="80" y1="80" x2="176" y2="176" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#22D3EE"/>
+      <stop offset="100%" stop-color="#3B82F6"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="256" height="256" rx="56" fill="url(#bg)"/>
+  <rect x="2" y="2" width="252" height="252" rx="54" stroke="url(#glow)" stroke-width="3" stroke-opacity="0.45"/>
+  <circle cx="128" cy="128" r="78" fill="url(#glow)" opacity="0.16"/>
+
+  <!-- Code brackets -->
+  <path d="M78 92 L54 128 L78 164" stroke="#67E8F9" stroke-width="10" stroke-linecap="round" stroke-linejoin="round" fill="none" opacity="0.9"/>
+  <path d="M178 92 L202 128 L178 164" stroke="#67E8F9" stroke-width="10" stroke-linecap="round" stroke-linejoin="round" fill="none" opacity="0.9"/>
+
+  <!-- Telegram-style paper plane -->
+  <path d="M92 128 L176 86 L148 170 L132 136 L92 128 Z" fill="url(#plane)"/>
+  <path d="M132 136 L176 86 L116 122 Z" fill="#E0F2FE" opacity="0.35"/>
+  <path d="M132 136 L148 170 L116 122 Z" fill="#0F172A" opacity="0.25"/>
+</svg>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds **yantr-bot**, a Yantr custom app that runs [OpenCode Telegram Bot](https://github.com/grinev/opencode-telegram-bot) together with OpenCode in a locally built image.

## What it does
- Telegram client for OpenCode so you can run AI coding tasks from your phone
- Bundles `@grinev/opencode-telegram-bot` and `opencode-ai` in a Dockerfile (`customapp: true`) instead of installing packages on every container start
- Persists OpenCode/bot state in the `yantr_bot_data` named volume (`HOME=/app`)
- Restricts access to `TELEGRAM_ALLOWED_USER_ID`; OpenCode auto-restarts when health checks fail

## Setup
1. Create a bot with [@BotFather](https://t.me/BotFather) and set `TELEGRAM_BOT_TOKEN`
2. Get your numeric user ID from [@userinfobot](https://t.me/userinfobot) and set `TELEGRAM_ALLOWED_USER_ID`

No host ports are published — the bot talks outbound to Telegram and to OpenCode on `localhost:4096` inside the container.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6d584014-57ff-4390-8225-15b3c1106185?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6d584014-57ff-4390-8225-15b3c1106185&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

